### PR TITLE
Python 2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build/
 dist/
 __pycache__/
+*.py[cod]
 htmlcov/
 
 .coverage
@@ -13,3 +14,6 @@ htmlcov/
 *.html
 *.pdf
 _build/
+
+.cache
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - 2.7
   - 3.5
 
 notifications:
@@ -8,7 +9,7 @@ notifications:
 # Install packages
 install:
   - sudo apt-get update
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
@@ -25,4 +26,3 @@ install:
 # Run test
 script:
   - "py.test tests --cov=stitch --cov-report html --run-slow tests/"
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION ipython pypandoc jupyter_core jupyter_client jupyter notebook matplotlib pandas doctr sphinx_rtd_theme bokeh holoviews altair numpydoc
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION ipython pypandoc jupyter_core jupyter_client jupyter notebook matplotlib pandas sphinx_rtd_theme bokeh holoviews altair numpydoc
   - source activate test-environment
   - jupyter kernelspec list
   - pip install -e .[dev]

--- a/examples/timeseries.md
+++ b/examples/timeseries.md
@@ -215,7 +215,10 @@ def download_one(date):
         'Connection': 'keep-alive',
         'DNT': '1',
     }
-    os.makedirs('data/timeseries', exist_ok=True)
+    try:
+        os.makedirs('data/timeseries')
+    except os.error:
+        pass
     with open('url_7.txt') as f:
         data = f.read().strip()
 
@@ -751,4 +754,3 @@ I'd recommend reading the [notebooks](http://www.statsmodels.org/dev/examples/in
 We also didn't get to talk at all about Skipper Seabold's work on VARs, but maybe some other time.
 
 As always, [feedback is welcome](https://twitter.com/tomaugspurger).
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 from os import path
-
+from io import open
 import versioneer
 
 
@@ -30,6 +30,8 @@ setup(
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: MIT License',
 
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
@@ -43,7 +45,7 @@ setup(
                       'nbconvert', 'pandocfilters', 'pypandoc', 'click'],
 
     extras_require={
-        'dev': ['pytest', 'pytest-cov', 'sphinx', 'pandas', 'matplotlib'],
+        'dev': ['pytest', 'pytest-cov', 'sphinx', 'pandas', 'matplotlib', 'tox'],
     },
     include_package_data=True,
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
                       'nbconvert', 'pandocfilters', 'pypandoc', 'click'],
 
     extras_require={
-        'dev': ['pytest', 'pytest-cov', 'sphinx', 'pandas', 'matplotlib', 'tox'],
+        'dev': ['pytest>=3.0', 'pytest-cov', 'sphinx', 'pandas', 'matplotlib', 'tox'],
     },
     include_package_data=True,
     package_data={

--- a/stitch/cli.py
+++ b/stitch/cli.py
@@ -1,4 +1,6 @@
+from __future__ import unicode_literals
 import os
+import copy
 import click
 
 from .stitch import convert
@@ -25,7 +27,7 @@ def has_booktabs(extra_args):
     ]
 
 def enhance_args(to, no_standalone, no_self_contained, extra_args):
-    extra_args = extra_args.copy()
+    extra_args = copy.copy(extra_args)
     if not no_standalone and not ('-s' in extra_args or
                                   '--standalone' in extra_args):
         extra_args.append('--standalone')

--- a/stitch/options.py
+++ b/stitch/options.py
@@ -1,4 +1,12 @@
-from collections.abc import Mapping
+from __future__ import unicode_literals
+try:
+    from collections.abc import Mapping
+    text_type = str
+    binary_type = bytes
+except ImportError:
+    from collections import Mapping
+    text_type = unicode
+    binary_type = str
 from traitlets import TraitType, Enum
 
 
@@ -33,11 +41,11 @@ class Choice(Enum):
 class Str(TraitType):
 
     default_value = ''
-    info_text = "Choice from a set; unwraps pandoc's JSON AST"
+    info_text = "Str; unwraps pandoc's JSON AST"
 
     def validate(self, obj, value):
         if isinstance(value, Mapping):
             value = ' '.join(x['c'] for x in value['c'] if x['c'])
-        if isinstance(value, str) or value is None:
+        if isinstance(value, text_type) or value is None:
             return value
         self.error(obj, value)

--- a/stitch/stitch.py
+++ b/stitch/stitch.py
@@ -400,7 +400,10 @@ class Stitch(HasTraits):
             ext = mimetypes.guess_extension(key)
             filepath = os.path.join(self.resource_dir,
                                     "{}{}".format(chunk_name, ext))
-            os.makedirs(self.resource_dir, exist_ok=True)
+            try:
+                os.makedirs(self.resource_dir)
+            except os.error:
+                pass
             if ext == '.svg':
                 with open(filepath, 'wt') as f:
                     f.write(data)

--- a/stitch/stitch.py
+++ b/stitch/stitch.py
@@ -6,6 +6,7 @@ in the output.
 # Copyright (c) Jan Schulz <jasc@gmx.net>
 # Copyright (c) IPython Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import unicode_literals
 import os
 import re
 import copy
@@ -13,7 +14,10 @@ import json
 import base64
 import mimetypes
 from collections import namedtuple
-from queue import Empty
+try:
+    from queue import Empty
+except ImportError:
+    from Queue import Empty
 
 from traitlets import HasTraits
 from jupyter_client.manager import start_new_kernel
@@ -145,7 +149,7 @@ class Stitch(HasTraits):
             thing, attr = attr.split('.', 1)
             return getattr(getattr(self, thing), attr)
         else:
-            return getattr(super(), attr)
+            return getattr(super(Stitch, self), attr)
 
     def has_trait(self, name):
         # intercepted `.`ed names for ease of use
@@ -157,7 +161,7 @@ class Stitch(HasTraits):
                 return False
             return accessor.has_trait(name)
         else:
-            return super().has_trait(name)
+            return super(Stitch, self).has_trait(name)
 
     def set_trait(self, name, value):
         # intercepted `.`ed names for ease of use
@@ -166,7 +170,7 @@ class Stitch(HasTraits):
             accessor = getattr(self, ns)
             return accessor.set_trait(name, value)
         else:
-            return super().set_trait(name, value)
+            return super(Stitch, self).set_trait(name, value)
 
     @staticmethod
     def name_resource_dir(name):
@@ -413,10 +417,10 @@ class Stitch(HasTraits):
         return block
 
 
-def convert_file(input_file: str,
-                 to: str,
+def convert_file(input_file,
+                 to,
                  extra_args=(),
-                 output_file=None) -> None:
+                 output_file=None):
     """
     Convert a markdown ``input_file`` to ``to``.
 
@@ -436,8 +440,8 @@ def convert_file(input_file: str,
     convert(source, to, extra_args=extra_args, output_file=output_file)
 
 
-def convert(source: str, to: str, extra_args=(),
-            output_file: str=None) -> None:
+def convert(source, to, extra_args=(),
+            output_file=None):
     """
     Convert a source document to an output file.
 
@@ -472,7 +476,7 @@ def convert(source: str, to: str, extra_args=(),
         print(newdoc)
 
 
-def kernel_factory(kernel_name: str) -> KernelPair:
+def kernel_factory(kernel_name):
     """
     Start a new kernel.
 
@@ -574,7 +578,7 @@ def format_output_prompt(output, number):
 # Input Processing
 # ----------------
 
-def tokenize(source: str) -> dict:
+def tokenize(source):
     """
     Convert a document to pandoc's JSON AST.
     """
@@ -590,7 +594,7 @@ def validate_options(options_line):
         raise TypeError("Invalid chunk options %s" % options_line)
 
 
-def preprocess(source: str) -> str:
+def preprocess(source):
     """
     Process a source file prior to tokenezation.
 
@@ -745,7 +749,7 @@ def execute_block(block, kp, timeout=None):
     return messages
 
 
-def run_code(code: str, kp: KernelPair, timeout=None):
+def run_code(code, kp, timeout=None):
     '''
     Execute a code chunk, capturing the output.
 

--- a/stitch/stitch.py
+++ b/stitch/stitch.py
@@ -14,6 +14,7 @@ import json
 import base64
 import mimetypes
 from collections import namedtuple
+from io import open
 try:
     from queue import Empty
 except ImportError:
@@ -405,7 +406,7 @@ class Stitch(HasTraits):
             except os.error:
                 pass
             if ext == '.svg':
-                with open(filepath, 'wt') as f:
+                with open(filepath, 'wt', encoding='utf-8') as f:
                     f.write(data)
             else:
                 with open(filepath, 'wb') as f:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest
 from textwrap import dedent
 from stitch.stitch import Stitch
@@ -78,6 +79,3 @@ class TestOptionsKernel:
         meta, blocks = s.stitch(code)
         result = blocks[-1]['c'][0]['c'][1][0]['c']
         assert result == 'This is a caption'
-
-
-

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 import json
 import uuid
@@ -543,4 +544,3 @@ class TestStitcher:
         assert s.has_trait('fig.width')
         assert not s.has_trait('fake.width')
         assert not s.has_trait('fig.fake')
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py35
+[testenv]
+deps=pytest
+commands=py.test

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,4 @@
 envlist = py27,py35
 [testenv]
 deps=pytest
-commands=py.test
+commands=py.test {posargs}


### PR DESCRIPTION
this PR entails necessary changes and tests for Python 2 compatibility:

 - `io.open()` instead of `open()`
 - conditionally using `unicode()` instead of `str()`
 - conditionally using `collections` instead of `collections.abc`
 - conditionally using `Queue` instead of `queue`
 - `unicode_literals` everywhere
 - `copy.copy()` instead of `list.copy()`
 - removed the handful of type annotations that were there
 - using `super(cls, self)` instead of `super()`
 - `tox` for cross-version testing
 - removed `doctr` dependency as it was unused

All tests pass on both Python versions.