### PR TITLE
BUG: SVG non-ascii characters

### DIFF
--- a/stitch/stitch.py
+++ b/stitch/stitch.py
@@ -377,7 +377,7 @@ class Stitch(HasTraits):
         # TODO: interaction of output type and standalone.
         # TODO: this can be simplified, do the file-writing in one step
         def b64_encode(data):
-            return base64.encodebytes(data.encode('ascii')).decode('ascii')
+            return base64.encodebytes(data.encode('utf-8')).decode('ascii')
 
         # TODO: dict of attrs on Stitcher.
         image_keys = {'width', 'height'}

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -302,7 +302,8 @@ class TestIntegration:
         ```{python}
         %matplotlib inline
         import matplotlib.pyplot as plt
-        plt.plot(range(4), range(4));
+        plt.plot(range(4), range(4))
+        plt.title('Foo — Bar');  # That's an em dash
         ```
         ''')
         result = R.Stitch('foo', to=to).stitch(code)


### PR DESCRIPTION
encode as utf-8 before base64 encoding. Still decode as ascii, since b64 is ascii.