### PR TITLE
Nbconvert exporter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     },
     include_package_data=True,
     package_data={
-        'stitch': ['static/*'],
+        'stitch': ['static/*', 'templates/*'],
     },
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,8 @@ setup(
         'console_scripts': [
             'stitch=stitch.cli:cli',
         ],
+        'nbconvert.exporters': [
+            'stitch=stitch.exporter:StitchExporter',
+        ]
     },
 )

--- a/stitch/exporter.py
+++ b/stitch/exporter.py
@@ -1,0 +1,16 @@
+import os
+
+from nbconvert.exporters.markdown import MarkdownExporter
+from traitlets import default, Unicode
+
+
+class StitchExporter(MarkdownExporter):
+    @default('template_file')
+    def _template_file_default(self):
+        return 'stitch_template'
+
+    @property
+    def template_path(self):
+        return super().template_path + [os.path.join(os.path.dirname(__file__), "templates")]
+
+    kernel_name = Unicode(default_value='python')

--- a/stitch/templates/stitch_template.tpl
+++ b/stitch/templates/stitch_template.tpl
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 {%- endblock output_prompt %}
 
 {% block input %}
-```{python}
+```{{ '{' }}{{ nb.metadata.kernelspec.name }}, echo=False{{ '}' }}
 {{ cell.source}}
 ```
 {% endblock input %}

--- a/stitch/templates/stitch_template.tpl
+++ b/stitch/templates/stitch_template.tpl
@@ -1,0 +1,97 @@
+{#
+
+This file was derived from the nbconvert. Its license follows:
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# Licensing terms
+
+This project is licensed under the terms of the Modified BSD License
+(also known as New or Revised or 3-Clause BSD), as follows:
+
+- Copyright (c) 2001-2015, IPython Development Team
+- Copyright (c) 2015-, Jupyter Development Team
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the Jupyter Development Team nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#}
+{% extends 'markdown.tpl' %}
+
+{% block in_prompt %}
+{% endblock in_prompt %}
+
+{% block output_prompt %}
+{%- endblock output_prompt %}
+
+{% block input %}
+```{python}
+{{ cell.source}}
+```
+{% endblock input %}
+
+{% block error %}
+{% endblock error %}
+
+{% block traceback_line %}
+{% endblock traceback_line %}
+
+{% block execute_result %}
+{% endblock execute_result %}
+
+{% block stream %}
+{% endblock stream %}
+
+{% block data_svg %}
+{% endblock data_svg %}
+
+{% block data_png %}
+{% endblock data_png %}
+
+{% block data_jpg %}
+{% endblock data_jpg %}
+
+{% block data_latex %}
+{% endblock data_latex %}
+
+{% block data_html scoped %}
+{% endblock data_html %}
+
+{% block data_markdown scoped %}
+{% endblock data_markdown %}
+
+{% block data_text scoped %}
+{% endblock data_text %}
+
+{% block markdowncell scoped %}
+{{ cell.source }}
+{% endblock markdowncell %}
+
+{% block unknowncell scoped %}
+unknown type  {{ cell.type }}
+{% endblock unknowncell %}


### PR DESCRIPTION
Closes https://github.com/pystitch/stitch/issues/24

This is a very rough implementation that I needed for work, so I figured I'd push it up for now. Still a lot of work to be done and I'll probably change names, but in theory

```bash
jupyter nbconvert --stdout --to=stitch Untitled.ipynb | stitch -t html -
```

should work.